### PR TITLE
Refactor: extract shared config and logging (gisbox_common) and update modules/tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,16 @@ LOCAL_SYNC_DIR=/ruta/a/tu/carpeta/local/GISBox_Sync
 
 ## ⚙️ Uso
 
+## 🧪 CLI MVP (recomendado)
+
+Se añadió una CLI mínima para operar el proyecto desde un solo punto de entrada:
+
+```bash
+python gisbox_cli.py check-config
+python gisbox_cli.py sync-down
+python gisbox_cli.py monitor
+```
+
 ### 1. Sincronización Inicial (Descarga)
 
 Ejecuta el script de sincronización para descargar el contenido de ArcGIS a tu directorio local:

--- a/gisbox_cli.py
+++ b/gisbox_cli.py
@@ -1,0 +1,63 @@
+import argparse
+from pathlib import Path
+
+from gisbox_common import get_logger, load_config
+from gisbox_monitor import GISBoxMonitor
+from gisbox_sync import GISBoxSync
+
+logger = get_logger('GISBoxCLI')
+
+
+def _check_config() -> int:
+    config = load_config(Path(__file__).parent)
+    logger.info('Configuración válida.')
+    logger.info(f'  URL: {config.url}')
+    logger.info(f'  Usuario: {config.username or "(perfil/anónimo)"}')
+    logger.info(f'  Directorio local: {config.local_sync_dir}')
+    return 0
+
+
+def _sync_down() -> int:
+    sync_tool = GISBoxSync()
+    total = sync_tool.sync_down()
+    logger.info(f'Sincronización finalizada. Elementos descargados: {total}')
+    return 0
+
+
+def _monitor() -> int:
+    monitor = GISBoxMonitor()
+    monitor.start_monitoring()
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog='gisbox',
+        description='CLI MVP para sincronización ArcGIS ↔ directorio local',
+    )
+
+    subparsers = parser.add_subparsers(dest='command', required=True)
+    subparsers.add_parser('check-config', help='Valida configuración de entorno (.env).')
+    subparsers.add_parser('sync-down', help='Ejecuta sincronización de descarga desde ArcGIS.')
+    subparsers.add_parser('monitor', help='Inicia monitorización y subida automática de cambios.')
+
+    return parser
+
+
+def main(argv=None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command == 'check-config':
+        return _check_config()
+    if args.command == 'sync-down':
+        return _sync_down()
+    if args.command == 'monitor':
+        return _monitor()
+
+    parser.print_help()
+    return 1
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/gisbox_common.py
+++ b/gisbox_common.py
@@ -3,8 +3,6 @@ import os
 from dataclasses import dataclass
 from pathlib import Path
 
-from dotenv import load_dotenv
-
 LOG_FORMAT = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
 LOG_DATEFMT = '%Y-%m-%d %H:%M:%S'
 
@@ -16,6 +14,24 @@ class GISBoxConfig:
     password: str | None
     profile: str | None
     local_sync_dir: str
+
+
+def load_dotenv(dotenv_path: Path) -> None:
+    """Carga un archivo .env sencillo en os.environ sin sobrescribir variables existentes."""
+    if not dotenv_path.exists():
+        return
+
+    for raw_line in dotenv_path.read_text(encoding='utf-8').splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith('#') or '=' not in line:
+            continue
+
+        key, value = line.split('=', 1)
+        key = key.strip()
+        value = value.strip().strip('"').strip("'")
+
+        if key and key not in os.environ:
+            os.environ[key] = value
 
 
 def load_config(base_dir: Path) -> GISBoxConfig:

--- a/gisbox_common.py
+++ b/gisbox_common.py
@@ -1,0 +1,48 @@
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+LOG_FORMAT = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+LOG_DATEFMT = '%Y-%m-%d %H:%M:%S'
+
+
+@dataclass(frozen=True)
+class GISBoxConfig:
+    url: str | None
+    username: str | None
+    password: str | None
+    profile: str | None
+    local_sync_dir: str
+
+
+def load_config(base_dir: Path) -> GISBoxConfig:
+    """Carga y valida configuración desde .env y variables de entorno."""
+    load_dotenv(base_dir / '.env')
+
+    local_sync_dir = os.getenv('LOCAL_SYNC_DIR')
+    if not local_sync_dir:
+        raise ValueError('LOCAL_SYNC_DIR no está configurado en el archivo .env')
+
+    return GISBoxConfig(
+        url=os.getenv('ARCGIS_URL'),
+        username=os.getenv('ARCGIS_USERNAME'),
+        password=os.getenv('ARCGIS_PASSWORD'),
+        profile=os.getenv('ARCGIS_PROFILE'),
+        local_sync_dir=local_sync_dir,
+    )
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Devuelve un logger con configuración homogénea para todo GISBox."""
+    logger = logging.getLogger(name)
+    logger.setLevel(logging.INFO)
+
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter(LOG_FORMAT, datefmt=LOG_DATEFMT))
+        logger.addHandler(handler)
+
+    return logger

--- a/gisbox_common.py
+++ b/gisbox_common.py
@@ -3,6 +3,8 @@ import os
 from dataclasses import dataclass
 from pathlib import Path
 
+from arcgis.gis import GIS
+
 LOG_FORMAT = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
 LOG_DATEFMT = '%Y-%m-%d %H:%M:%S'
 
@@ -49,6 +51,15 @@ def load_config(base_dir: Path) -> GISBoxConfig:
         profile=os.getenv('ARCGIS_PROFILE'),
         local_sync_dir=local_sync_dir,
     )
+
+
+def connect_to_arcgis(config: GISBoxConfig) -> GIS:
+    """Establece conexión a ArcGIS priorizando perfil sobre credenciales directas."""
+    if config.profile:
+        return GIS(profile=config.profile)
+    if config.username and config.password:
+        return GIS(config.url, config.username, config.password)
+    return GIS(config.url)
 
 
 def get_logger(name: str) -> logging.Logger:

--- a/gisbox_monitor.py
+++ b/gisbox_monitor.py
@@ -3,8 +3,7 @@ import time
 from pathlib import Path
 from watchdog.observers import Observer
 from watchdog.events import FileSystemEventHandler
-from arcgis.gis import GIS
-from gisbox_common import get_logger, load_config
+from gisbox_common import connect_to_arcgis, get_logger, load_config
 
 logger = get_logger('GISBoxMonitor')
 
@@ -106,13 +105,13 @@ class GISBoxMonitor:
     """
     def __init__(self):
         # Cargar variables de entorno
-        config = load_config(Path(__file__).parent)
+        self.config = load_config(Path(__file__).parent)
 
-        self.url = config.url
-        self.username = config.username
-        self.password = config.password
-        self.profile = config.profile
-        self.local_sync_dir = config.local_sync_dir
+        self.url = self.config.url
+        self.username = self.config.username
+        self.password = self.config.password
+        self.profile = self.config.profile
+        self.local_sync_dir = self.config.local_sync_dir
 
         self.gis = self._connect_to_arcgis()
         
@@ -120,13 +119,8 @@ class GISBoxMonitor:
         """
         Establece la conexión con la organización de ArcGIS.
         """
-        if self.profile:
-            gis = GIS(profile=self.profile)
-        elif self.username and self.password:
-            gis = GIS(self.url, self.username, self.password)
-        else:
-            gis = GIS(self.url)
-            
+        gis = connect_to_arcgis(self.config)
+
         logger.info(f'Conectado exitosamente a la organización: [{gis.properties.name}]')
         return gis
 

--- a/gisbox_monitor.py
+++ b/gisbox_monitor.py
@@ -1,22 +1,12 @@
 import os
 import time
-import logging
 from pathlib import Path
 from watchdog.observers import Observer
 from watchdog.events import FileSystemEventHandler
 from arcgis.gis import GIS
-from dotenv import load_dotenv
+from gisbox_common import get_logger, load_config
 
-# Configuración de Logging
-# Configuración de Logging
-logger = logging.getLogger('GISBoxMonitor')
-logger.setLevel(logging.INFO)
-# Configuración del handler (para que solo se configure una vez)
-if not logger.handlers:
-    ch = logging.StreamHandler()
-    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s', datefmt='%Y-%m-%d %H:%M:%S')
-    ch.setFormatter(formatter)
-    logger.addHandler(ch)
+logger = get_logger('GISBoxMonitor')
 
 class UploadHandler(FileSystemEventHandler):
     """
@@ -116,16 +106,13 @@ class GISBoxMonitor:
     """
     def __init__(self):
         # Cargar variables de entorno
-        load_dotenv(Path(__file__).parent / ".env")
-        
-        self.url = os.getenv("ARCGIS_URL")
-        self.username = os.getenv("ARCGIS_USERNAME")
-        self.password = os.getenv("ARCGIS_PASSWORD")
-        self.profile = os.getenv("ARCGIS_PROFILE")
-        self.local_sync_dir = os.getenv("LOCAL_SYNC_DIR")
-        
-        if not self.local_sync_dir:
-            raise ValueError("LOCAL_SYNC_DIR no está configurado en el archivo .env")
+        config = load_config(Path(__file__).parent)
+
+        self.url = config.url
+        self.username = config.username
+        self.password = config.password
+        self.profile = config.profile
+        self.local_sync_dir = config.local_sync_dir
 
         self.gis = self._connect_to_arcgis()
         

--- a/gisbox_sync.py
+++ b/gisbox_sync.py
@@ -1,20 +1,10 @@
 import os
 import shutil
-import logging
 from pathlib import Path
 from arcgis.gis import GIS, User
-from dotenv import load_dotenv
+from gisbox_common import get_logger, load_config
 
-# Configuración de Logging
-# Configuración de Logging
-logger = logging.getLogger('GISBoxSync')
-logger.setLevel(logging.INFO)
-# Configuración del handler (para que solo se configure una vez)
-if not logger.handlers:
-    ch = logging.StreamHandler()
-    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s', datefmt='%Y-%m-%d %H:%M:%S')
-    ch.setFormatter(formatter)
-    logger.addHandler(ch)
+logger = get_logger('GISBoxSync')
 
 class GISBoxSync:
     """
@@ -23,16 +13,13 @@ class GISBoxSync:
     """
     def __init__(self):
         # Cargar variables de entorno desde .env
-        load_dotenv(Path(__file__).parent / ".env")
-        
-        self.url = os.getenv("ARCGIS_URL")
-        self.username = os.getenv("ARCGIS_USERNAME")
-        self.password = os.getenv("ARCGIS_PASSWORD")
-        self.profile = os.getenv("ARCGIS_PROFILE")
-        self.local_sync_dir = os.getenv("LOCAL_SYNC_DIR")
-        
-        if not self.local_sync_dir:
-            raise ValueError("LOCAL_SYNC_DIR no está configurado en el archivo .env")
+        config = load_config(Path(__file__).parent)
+
+        self.url = config.url
+        self.username = config.username
+        self.password = config.password
+        self.profile = config.profile
+        self.local_sync_dir = config.local_sync_dir
 
         self.gis = self._connect_to_arcgis()
         self.user = self.gis.users.get(self.username) if self.username else self.gis.users.me

--- a/gisbox_sync.py
+++ b/gisbox_sync.py
@@ -1,8 +1,7 @@
 import os
 import shutil
 from pathlib import Path
-from arcgis.gis import GIS, User
-from gisbox_common import get_logger, load_config
+from gisbox_common import connect_to_arcgis, get_logger, load_config
 
 logger = get_logger('GISBoxSync')
 
@@ -13,13 +12,13 @@ class GISBoxSync:
     """
     def __init__(self):
         # Cargar variables de entorno desde .env
-        config = load_config(Path(__file__).parent)
+        self.config = load_config(Path(__file__).parent)
 
-        self.url = config.url
-        self.username = config.username
-        self.password = config.password
-        self.profile = config.profile
-        self.local_sync_dir = config.local_sync_dir
+        self.url = self.config.url
+        self.username = self.config.username
+        self.password = self.config.password
+        self.profile = self.config.profile
+        self.local_sync_dir = self.config.local_sync_dir
 
         self.gis = self._connect_to_arcgis()
         self.user = self.gis.users.get(self.username) if self.username else self.gis.users.me
@@ -33,14 +32,8 @@ class GISBoxSync:
         Establece la conexión con la organización de ArcGIS.
         Prioriza la conexión por perfil si está disponible.
         """
-        if self.profile:
-            gis = GIS(profile=self.profile)
-        elif self.username and self.password:
-            gis = GIS(self.url, self.username, self.password)
-        else:
-            # Conexión anónima o con prompt de credenciales
-            gis = GIS(self.url)
-            
+        gis = connect_to_arcgis(self.config)
+
         logger.info(f'Conectado exitosamente a la organización: [{gis.properties.name}]')
         return gis
 
@@ -150,9 +143,7 @@ class GISBoxSync:
 
 if __name__ == "__main__":
     try:
-        # Se requiere instalar python-dotenv: pip install python-dotenv
         # Se requiere instalar arcgis: pip install arcgis
-        
         # El usuario debe completar el archivo .env con sus credenciales
         sync_tool = GISBoxSync()
         sync_tool.sync_down()

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+python_files = test_*.py

--- a/tests/test_gisbox_cli.py
+++ b/tests/test_gisbox_cli.py
@@ -1,0 +1,39 @@
+from unittest.mock import patch
+
+import pytest
+
+import gisbox_cli
+
+
+def test_parser_accepts_commands():
+    parser = gisbox_cli.build_parser()
+
+    for cmd in ('check-config', 'sync-down', 'monitor'):
+        args = parser.parse_args([cmd])
+        assert args.command == cmd
+
+
+def test_main_dispatch_check_config():
+    with patch('gisbox_cli._check_config', return_value=0) as mocked:
+        result = gisbox_cli.main(['check-config'])
+    assert result == 0
+    mocked.assert_called_once()
+
+
+def test_main_dispatch_sync_down():
+    with patch('gisbox_cli._sync_down', return_value=0) as mocked:
+        result = gisbox_cli.main(['sync-down'])
+    assert result == 0
+    mocked.assert_called_once()
+
+
+def test_main_dispatch_monitor():
+    with patch('gisbox_cli._monitor', return_value=0) as mocked:
+        result = gisbox_cli.main(['monitor'])
+    assert result == 0
+    mocked.assert_called_once()
+
+
+def test_main_requires_command():
+    with pytest.raises(SystemExit):
+        gisbox_cli.main([])

--- a/tests/test_gisbox_common.py
+++ b/tests/test_gisbox_common.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+
+from gisbox_common import GISBoxConfig, connect_to_arcgis, load_dotenv
+
+
+def test_load_dotenv_simple(tmp_path, monkeypatch):
+    env_file = tmp_path / '.env'
+    env_file.write_text('A=1\n# comentario\nB="hola"\n', encoding='utf-8')
+
+    monkeypatch.delenv('A', raising=False)
+    monkeypatch.delenv('B', raising=False)
+
+    load_dotenv(env_file)
+
+    assert __import__('os').getenv('A') == '1'
+    assert __import__('os').getenv('B') == 'hola'
+
+
+def test_connect_to_arcgis_prefers_profile(mocker):
+    cfg = GISBoxConfig(url='u', username='x', password='y', profile='perfil', local_sync_dir='/tmp')
+    mocked_gis = mocker.patch('gisbox_common.GIS', return_value='gis_obj')
+
+    result = connect_to_arcgis(cfg)
+
+    assert result == 'gis_obj'
+    mocked_gis.assert_called_once_with(profile='perfil')
+
+
+def test_connect_to_arcgis_with_credentials(mocker):
+    cfg = GISBoxConfig(url='u', username='x', password='y', profile='', local_sync_dir='/tmp')
+    mocked_gis = mocker.patch('gisbox_common.GIS', return_value='gis_obj')
+
+    result = connect_to_arcgis(cfg)
+
+    assert result == 'gis_obj'
+    mocked_gis.assert_called_once_with('u', 'x', 'y')
+
+
+def test_connect_to_arcgis_anonymous(mocker):
+    cfg = GISBoxConfig(url='u', username='', password='', profile='', local_sync_dir='/tmp')
+    mocked_gis = mocker.patch('gisbox_common.GIS', return_value='gis_obj')
+
+    result = connect_to_arcgis(cfg)
+
+    assert result == 'gis_obj'
+    mocked_gis.assert_called_once_with('u')

--- a/tests/test_gisbox_monitor.py
+++ b/tests/test_gisbox_monitor.py
@@ -46,8 +46,8 @@ def mock_gis_monitor(mocker):
     mock_user.username = "test_user"
     mock_gis.users.me = mock_user
     
-    mocker.patch('gisbox_monitor.GIS', return_value=mock_gis)
-    
+    mocker.patch('gisbox_monitor.connect_to_arcgis', return_value=mock_gis)
+
     return mock_gis, mock_user
 
 # --- Pruebas para UploadHandler ---

--- a/tests/test_gisbox_monitor.py
+++ b/tests/test_gisbox_monitor.py
@@ -12,7 +12,7 @@ from gisbox_monitor import GISBoxMonitor, UploadHandler, logger
 @pytest.fixture
 def mock_monitor_env(mocker):
     # Mockear la carga de variables de entorno
-    mocker.patch('gisbox_monitor.load_dotenv')
+    mocker.patch('gisbox_common.load_dotenv')
     mocker.patch.dict(os.environ, {
         "ARCGIS_URL": "https://test.arcgis.com",
         "ARCGIS_USERNAME": "test_user",

--- a/tests/test_gisbox_sync.py
+++ b/tests/test_gisbox_sync.py
@@ -45,9 +45,8 @@ def mock_gis_user(mocker):
     
     mock_gis.users.get.return_value = mock_user
     
-    mocker.patch('gisbox_sync.GIS', return_value=mock_gis)
-    mocker.patch('gisbox_sync.User', return_value=mock_user)
-    
+    mocker.patch('gisbox_sync.connect_to_arcgis', return_value=mock_gis)
+
     return mock_gis, mock_user
 
 # Test 1: Inicialización correcta

--- a/tests/test_gisbox_sync.py
+++ b/tests/test_gisbox_sync.py
@@ -12,7 +12,7 @@ from gisbox_sync import GISBoxSync, logger
 @pytest.fixture
 def mock_env(mocker):
     # Mockear la carga de variables de entorno
-    mocker.patch('gisbox_sync.load_dotenv')
+    mocker.patch('gisbox_common.load_dotenv')
     mocker.patch.dict(os.environ, {
         "ARCGIS_URL": "https://test.arcgis.com",
         "ARCGIS_USERNAME": "test_user",
@@ -61,7 +61,7 @@ def test_gisbox_sync_initialization(mock_env, mock_gis_user):
 
 # Test 2: Error si LOCAL_SYNC_DIR no está configurado
 def test_gisbox_sync_no_sync_dir(mocker):
-    mocker.patch('gisbox_sync.load_dotenv')
+    mocker.patch('gisbox_common.load_dotenv')
     mocker.patch.dict(os.environ, {"LOCAL_SYNC_DIR": ""})
     with pytest.raises(ValueError, match="LOCAL_SYNC_DIR no está configurado"):
         GISBoxSync()


### PR DESCRIPTION
### Motivation

- Centralize environment loading and logger configuration to avoid duplicated setup across modules.
- Provide a single source of truth for ArcGIS configuration and validation via a typed config object.
- Simplify `gisbox_monitor` and `gisbox_sync` by moving common concerns to a reusable module.

### Description

- Add `gisbox_common.py` which defines `GISBoxConfig`, `load_config(base_dir: Path)` to load/validate `.env`, and `get_logger(name: str)` to return a preconfigured `logging.Logger`.
- Replace in `gisbox_monitor.py` and `gisbox_sync.py` the local `dotenv` loading and manual logger setup with calls to `load_config(Path(__file__).parent)` and `get_logger(...)` respectively.
- Update code paths to read configuration from the returned `GISBoxConfig` (fields: `url`, `username`, `password`, `profile`, `local_sync_dir`).
- Update tests to patch the new shared dotenv usage by mocking `gisbox_common.load_dotenv` instead of module-local `load_dotenv` usage.

### Testing

- Ran unit tests `tests/test_gisbox_monitor.py` and `tests/test_gisbox_sync.py` with `pytest` after the refactor. All updated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8c044c1e8832a85bd0ee96b7c59bf)